### PR TITLE
Use only "safe" selectors

### DIFF
--- a/ActionKit.podspec
+++ b/ActionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ActionKit"
-  s.version      = "1.0"
+  s.version      = "1.0.1"
   s.summary      = "ActionKit is a easy to use framework that wraps the target-action design paradigm into a closure design."
   s.description  = <<-DESC
                     ActionKit is a experimental, light-weight, easy to use framework that wraps the target-action design paradigm into a less verbose, cleaner format. It shortens target-action method calls by removing the target and replacing the selector with a closure.

--- a/ActionKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ActionKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
-   version = "1.0">
+   version = "1.0.1">
    <FileRef
       location = "self:ActionKit.xcodeproj">
    </FileRef>

--- a/ActionKit.xcodeproj/xcshareddata/xcschemes/ActionKit.xcscheme
+++ b/ActionKit.xcodeproj/xcshareddata/xcschemes/ActionKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ActionKit/1.0.1/ActionKit.podspec
+++ b/ActionKit/1.0.1/ActionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ActionKit"
-  s.version      = "1.0"
+  s.version      = "1.0.1"
   s.summary      = "ActionKit is a easy to use framework that wraps the target-action design paradigm into a closure design."
   s.description  = <<-DESC
                     ActionKit is a experimental, light-weight, easy to use framework that wraps the target-action design paradigm into a less verbose, cleaner format. It shortens target-action method calls by removing the target and replacing the selector with a closure.

--- a/ActionKit/ActionKit.swift
+++ b/ActionKit/ActionKit.swift
@@ -9,29 +9,6 @@
 import Foundation
 import UIKit
 
-// All 19 UIControlEvents
-let runClosureTouchDown = "runClosureTouchDown:"
-let runClosureTouchDownRepeat = "runClosureTouchDownRepeat:"
-let runClosureTouchDragInside = "runClosureTouchDragInside:"
-let runClosureTouchDragOutside = "runClosureTouchDragOutside:"
-let runClosureTouchDragEnter = "runClosureTouchDragEnter:"
-let runClosureTouchDragExit = "runClosureTouchDragExit:"
-let runClosureTouchUpInside = "runClosureTouchUpInside:"
-let runClosureTouchUpOutside = "runClosureTouchUpOutside:"
-let runClosureTouchCancel = "runClosureTouchCancel:"
-let runClosureValueChanged = "runClosureValueChanged:"
-let runClosureEditingDidBegin = "runClosureEditingDidBegin:"
-let runClosureEditingChanged = "runClosureEditingChanged:"
-let runClosureEditingDidEnd = "runClosureEditingDidEnd:"
-let runClosureEditingDidEndOnExit = "runClosureEditingDidEndOnExit:"
-let runClosureAllTouchEvents = "runClosureAllTouchEvents:"
-let runClosureAllEditingEvents = "runClosureAllEditingEvents:"
-let runClosureApplicationReserved = "runClosureApplicationReserved:"
-let runClosureSystemReserved = "runClosureSystemReserved:"
-let runClosureAllEvents = "runClosureAllEvents:"
-
-
-
 
 class ActionKitSingleton {
     var controlAndEventsDict: Dictionary<UIControl, Dictionary<UIControlEvents, () -> Void>> = Dictionary()

--- a/ActionKit/Info.plist
+++ b/ActionKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ActionKit/UIControl+ActionKit.swift
+++ b/ActionKit/UIControl+ActionKit.swift
@@ -15,50 +15,75 @@ extension UIControlEvents: Hashable {
     }
 }
 
+private extension Selector {
+    
+    // All 19 UIControlEvents
+    static let runClosureTouchDown              = #selector(ActionKitSingleton.runClosureTouchDown(_:))
+    static let runClosureTouchDownRepeat        = #selector(ActionKitSingleton.runClosureTouchDownRepeat(_:))
+    static let runClosureTouchDragInside        = #selector(ActionKitSingleton.runClosureTouchDragInside(_:))
+    static let runClosureTouchDragOutside       = #selector(ActionKitSingleton.runClosureTouchDragOutside(_:))
+    static let runClosureTouchDragEnter         = #selector(ActionKitSingleton.runClosureTouchDragEnter(_:))
+    static let runClosureTouchDragExit          = #selector(ActionKitSingleton.runClosureTouchDragExit(_:))
+    static let runClosureTouchUpInside          = #selector(ActionKitSingleton.runClosureTouchUpInside(_:))
+    static let runClosureTouchUpOutside         = #selector(ActionKitSingleton.runClosureTouchUpOutside(_:))
+    static let runClosureTouchCancel            = #selector(ActionKitSingleton.runClosureTouchCancel(_:))
+    static let runClosureValueChanged           = #selector(ActionKitSingleton.runClosureValueChanged(_:))
+    static let runClosureEditingDidBegin        = #selector(ActionKitSingleton.runClosureEditingDidBegin(_:))
+    static let runClosureEditingChanged         = #selector(ActionKitSingleton.runClosureEditingChanged(_:))
+    static let runClosureEditingDidEnd          = #selector(ActionKitSingleton.runClosureEditingDidEnd(_:))
+    static let runClosureEditingDidEndOnExit    = #selector(ActionKitSingleton.runClosureEditingDidEndOnExit(_:))
+    static let runClosureAllTouchEvents         = #selector(ActionKitSingleton.runClosureAllTouchEvents(_:))
+    static let runClosureAllEditingEvents       = #selector(ActionKitSingleton.runClosureAllEditingEvents(_:))
+    static let runClosureApplicationReserved    = #selector(ActionKitSingleton.runClosureApplicationReserved(_:))
+    static let runClosureSystemReserved         = #selector(ActionKitSingleton.runClosureSystemReserved(_:))
+    static let runClosureAllEvents              = #selector(ActionKitSingleton.runClosureAllEvents(_:))
+
+}
+
 public extension UIControl {
     
     func removeControlEvent(controlEvents: UIControlEvents) {
         switch controlEvents {
         case let x where x.contains(.TouchDown):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDown), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDown, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDownRepeat):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDownRepeat), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDownRepeat, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDragInside):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDragInside), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDragInside, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDragOutside):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDragOutside), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDragOutside, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDragEnter):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDragEnter), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDragEnter, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDragExit):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDragExit), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDragExit, forControlEvents: controlEvents)
         case let x where x.contains(.TouchUpInside):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchUpInside), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchUpInside, forControlEvents: controlEvents)
         case let x where x.contains(.TouchUpOutside):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchUpOutside), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchUpOutside, forControlEvents: controlEvents)
         case let x where x.contains(.TouchCancel):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchCancel), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchCancel, forControlEvents: controlEvents)
         case let x where x.contains(.ValueChanged):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureValueChanged), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureValueChanged, forControlEvents: controlEvents)
         case let x where x.contains(.EditingDidBegin):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureEditingDidBegin), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureEditingDidBegin, forControlEvents: controlEvents)
         case let x where x.contains(.EditingChanged):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureEditingChanged), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureEditingChanged, forControlEvents: controlEvents)
         case let x where x.contains(.EditingDidEnd):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureEditingDidEnd), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureEditingDidEnd, forControlEvents: controlEvents)
         case let x where x.contains(.EditingDidEndOnExit):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureEditingDidEndOnExit), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureEditingDidEndOnExit, forControlEvents: controlEvents)
         case let x where x.contains(.AllTouchEvents):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureAllTouchEvents), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureAllTouchEvents, forControlEvents: controlEvents)
         case let x where x.contains(.AllEditingEvents):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureAllEditingEvents), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureAllEditingEvents, forControlEvents: controlEvents)
         case let x where x.contains(.ApplicationReserved):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureApplicationReserved), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureApplicationReserved, forControlEvents: controlEvents)
         case let x where x.contains(.SystemReserved):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureSystemReserved), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureSystemReserved, forControlEvents: controlEvents)
         case let x where x.contains(.AllEvents):
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureAllEvents), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureAllEvents, forControlEvents: controlEvents)
         default:
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchUpInside), forControlEvents: controlEvents)
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchUpInside, forControlEvents: controlEvents)
         }
         
         ActionKitSingleton.sharedInstance.removeAction(self, controlEvent: controlEvents)
@@ -68,45 +93,45 @@ public extension UIControl {
         
         switch controlEvents {
         case let x where x.contains(.TouchDown):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDown), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDown, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDownRepeat):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDownRepeat), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDownRepeat, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDragInside):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDragInside), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDragInside, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDragOutside):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDragOutside), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDragOutside, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDragEnter):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDragEnter), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDragEnter, forControlEvents: controlEvents)
         case let x where x.contains(.TouchDragExit):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchDragExit), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDragExit, forControlEvents: controlEvents)
         case let x where x.contains(.TouchUpInside):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchUpInside), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchUpInside, forControlEvents: controlEvents)
         case let x where x.contains(.TouchUpOutside):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchUpOutside), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchUpOutside, forControlEvents: controlEvents)
         case let x where x.contains(.TouchCancel):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchCancel), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchCancel, forControlEvents: controlEvents)
         case let x where x.contains(.ValueChanged):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureValueChanged), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureValueChanged, forControlEvents: controlEvents)
         case let x where x.contains(.EditingDidBegin):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureEditingDidBegin), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureEditingDidBegin, forControlEvents: controlEvents)
         case let x where x.contains(.EditingChanged):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureEditingChanged), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureEditingChanged, forControlEvents: controlEvents)
         case let x where x.contains(.EditingDidEnd):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureEditingDidEnd), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureEditingDidEnd, forControlEvents: controlEvents)
         case let x where x.contains(.EditingDidEndOnExit):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureEditingDidEndOnExit), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureEditingDidEndOnExit, forControlEvents: controlEvents)
         case let x where x.contains(.AllTouchEvents):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureAllTouchEvents), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureAllTouchEvents, forControlEvents: controlEvents)
         case let x where x.contains(.AllEditingEvents):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureAllEditingEvents), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureAllEditingEvents, forControlEvents: controlEvents)
         case let x where x.contains(.ApplicationReserved):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureApplicationReserved), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureApplicationReserved, forControlEvents: controlEvents)
         case let x where x.contains(.SystemReserved):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureSystemReserved), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureSystemReserved, forControlEvents: controlEvents)
         case let x where x.contains(.AllEvents):
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureAllEvents), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureAllEvents, forControlEvents: controlEvents)
         default:
-            self.addTarget(ActionKitSingleton.sharedInstance, action: Selector(runClosureTouchUpInside), forControlEvents: controlEvents)
+            self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchUpInside, forControlEvents: controlEvents)
         }
         
         ActionKitSingleton.sharedInstance.addAction(self, controlEvent: controlEvents, closure: closure)

--- a/ActionKit/UIGestureRecognizer+ActionKit.swift
+++ b/ActionKit/UIGestureRecognizer+ActionKit.swift
@@ -9,15 +9,20 @@
 import Foundation
 import UIKit
 
+private extension Selector {
+    
+    static let runGesture = #selector(ActionKitSingleton.runGesture(_:))
+    
+}
+
 public extension UIGestureRecognizer {
     
     convenience init(name: String = "", closure: () -> ()) {
-        self.init(target: ActionKitSingleton.sharedInstance, action: Selector("runGesture:"))
+        self.init(target: ActionKitSingleton.sharedInstance, action: .runGesture)
         ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: closure)
     }
     
     func addClosure(name: String, closure: () -> ()) {
-//        self.addTarget(ActionKitSingleton.sharedInstance, action: Selector("runGesture:"))
         ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: closure)
     }
     
@@ -27,7 +32,7 @@ public extension UIGestureRecognizer {
             ActionKitSingleton.sharedInstance.removeGesture(self, name: name)
         } else {
             ActionKitSingleton.sharedInstance.removeGesture(self, name: name)
-            self.removeTarget(ActionKitSingleton.sharedInstance, action: Selector("runGesture:"))
+            self.removeTarget(ActionKitSingleton.sharedInstance, action: .runGesture)
         }
     }
 }

--- a/ActionKitDemo.xcodeproj/project.pbxproj
+++ b/ActionKitDemo.xcodeproj/project.pbxproj
@@ -309,10 +309,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -333,10 +329,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = ActionKitDemoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
@@ -424,7 +416,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ActionKit.${PRODUCT_NAME:rfc1034identifier}";
@@ -437,7 +428,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ActionKit.${PRODUCT_NAME:rfc1034identifier}";

--- a/ActionKitDemo.xcodeproj/project.pbxproj
+++ b/ActionKitDemo.xcodeproj/project.pbxproj
@@ -187,7 +187,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = ActionKit;
 				TargetAttributes = {
 					438CAE7B1B50198F00EA8B00 = {
@@ -321,6 +321,7 @@
 				INFOPLIST_FILE = ActionKitDemoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "ActionKit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ActionKitDemo.app/ActionKitDemo";
 			};
@@ -340,6 +341,7 @@
 				INFOPLIST_FILE = ActionKitDemoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "ActionKit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ActionKitDemo.app/ActionKitDemo";
 			};
@@ -363,6 +365,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -424,6 +427,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "ActionKit.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -436,6 +440,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "ActionKit.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/ActionKitDemo.xcodeproj/xcshareddata/xcschemes/ActionKitDemo.xcscheme
+++ b/ActionKitDemo.xcodeproj/xcshareddata/xcschemes/ActionKitDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ActionKitDemoTests/Info.plist
+++ b/ActionKitDemoTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>ActionKit.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>ActionKit.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -33,9 +33,9 @@ class ViewController: UIViewController {
             self.testButton.setTitle("Tapped!", forState: .Normal)
         }
         
-        oldTestButton.addTarget(self, action: Selector("tappedSelector:"), forControlEvents: .TouchUpInside)
+        oldTestButton.addTarget(self, action: #selector(ViewController.tappedSelector(_:)), forControlEvents: .TouchUpInside)
 
-        var tgr = UITapGestureRecognizer(name: "setRed") {
+        let tgr = UITapGestureRecognizer(name: "setRed") {
             self.view.backgroundColor = UIColor.redColor()
         }
         // The following three lines will replace the action for the red color gesture recognizer to just change the text of the first test button only. Only one action per gesture recognizer (or a control event for that matter)
@@ -44,7 +44,7 @@ class ViewController: UIViewController {
             self.testButton.setTitle("tapped once on the screen!", forState: .Normal)
         }
         
-        var dtgr = UITapGestureRecognizer(name: "setYellow") {
+        let dtgr = UITapGestureRecognizer(name: "setYellow") {
             self.view.backgroundColor = UIColor.yellowColor()
         }
         

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ActionKit is a experimental, light-weight, easy to use framework that wraps the 
 
 Licensed under the terms of the MIT license
 
-## Target-action example without ActionKit
+## Target-action example without ActionKit (prior to Swift 2.2)
 ```swift
 button.addTarget(self, action: Selector("buttonWasTapped:"), forControlEvents: .TouchUpInside)
 ```
@@ -19,9 +19,27 @@ func buttonWasTapped(sender: UIButton!) {
 }
 ```
 
+## Target-action example without ActionKit with Swift 2.2
+```swift
+button.addTarget(self, action: #selector(ViewController.buttonWasTapped(_:)), forControlEvents: .TouchUpInside)
+```
+
+
+```swift
+func buttonWasTapped(sender: UIButton!) {
+
+    self.button.setTitle("Button was tapped!", forState: .Normal)
+    
+}
+```
+
 ## Target-action example with ActionKit
 ```swift
-button.addControlEvent(.TouchUpInside) { self.button.setTitle("Button was tapped!", forState: .Normal) }
+button.addControlEvent(.TouchUpInside) {
+  
+  self.button.setTitle("Button was tapped!", forState: .Normal)
+
+}
 ```
 
 ## Methods
@@ -32,7 +50,11 @@ button.addControlEvent(.TouchUpInside) { self.button.setTitle("Button was tapped
 ```
 ##### Example
 ```swift
-button.addControlEvent(.TouchUpInside) { self.button.setTitle("Button was tapped!", forState: .Normal) }
+button.addControlEvent(.TouchUpInside) {
+  
+  self.button.setTitle("Button was tapped!", forState: .Normal)
+
+}
 ```
 #### Removing an action closure for a control event
 ```swift
@@ -49,7 +71,11 @@ button.removeControlEvent(.TouchUpInside)
 ```
 ##### Example
 ```swift
-var singleTapGestureRecognizer = UITapGestureRecognizer() { self.view.backgroundColor = UIColor.redColor() }
+var singleTapGestureRecognizer = UITapGestureRecognizer() {
+  
+  self.view.backgroundColor = UIColor.redColor()
+
+}
 ```
 #### Adding an action closure to a gesture recognizer
 ```swift
@@ -57,7 +83,11 @@ var singleTapGestureRecognizer = UITapGestureRecognizer() { self.view.background
 ```
 ##### Example
 ```swift
-singleTapGestureRecognizer.addActionClosure() { self.view.backgroundColor = UIColor.blueColor() }
+singleTapGestureRecognizer.addActionClosure() {
+  
+  self.view.backgroundColor = UIColor.blueColor()
+
+}
 ```
 #### Removing an action closure for a control event
 ```swift
@@ -87,11 +117,15 @@ ActionKit extends target-action functionality by providing easy to use methods t
  ActionKit is available through [CocoaPods](http://cocoapods.org). To install
  it, simply add the following line to your Podfile:
  
-    pod 'ActionKit', '~> 1.0'
+    pod 'ActionKit', '~> 1.0.1'
 
 ### Carthage
 
-1. Add the following to your *Cartfile*:
-  <br> `github "ActionKit/ActionKit"`
-2. Run `carthage update`
-3. Add the framework as described in [Carthage Readme](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)
+- 1. Add the following to your *Cartfile*:
+
+```
+    github "ActionKit/ActionKit" == 1.0.1
+``` 
+   
+- 2. Run `carthage update`
+- 3. Add the framework as described in [Carthage Readme](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)


### PR DESCRIPTION
This pull request extends the PR #14 (So please merge that pull request first).

It is unsafe to use selectors defined by String literal. And with Swift 2.2 it now possible to use the `#selector` syntax to point to a specific function.