### PR TITLE
Add an optional parameter (UIControl or UIGestureRecognizer) to the closures 

### DIFF
--- a/ActionKit.podspec
+++ b/ActionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ActionKit"
-  s.version      = "1.0.1"
+  s.version      = "1.0.2"
   s.summary      = "ActionKit is a easy to use framework that wraps the target-action design paradigm into a closure design."
   s.description  = <<-DESC
                     ActionKit is a experimental, light-weight, easy to use framework that wraps the target-action design paradigm into a less verbose, cleaner format. It shortens target-action method calls by removing the target and replacing the selector with a closure.

--- a/ActionKit.podspec
+++ b/ActionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ActionKit"
-  s.version      = "1.0.2"
+  s.version      = "1.1"
   s.summary      = "ActionKit is a easy to use framework that wraps the target-action design paradigm into a closure design."
   s.description  = <<-DESC
                     ActionKit is a experimental, light-weight, easy to use framework that wraps the target-action design paradigm into a less verbose, cleaner format. It shortens target-action method calls by removing the target and replacing the selector with a closure.

--- a/ActionKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ActionKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
-   version = "1.0.2">
+   version = "1.1.0">
    <FileRef
       location = "self:ActionKit.xcodeproj">
    </FileRef>

--- a/ActionKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ActionKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
-   version = "1.0.1">
+   version = "1.0.2">
    <FileRef
       location = "self:ActionKit.xcodeproj">
    </FileRef>

--- a/ActionKit/1.0.2/ActionKit.podspec
+++ b/ActionKit/1.0.2/ActionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ActionKit"
-  s.version      = "1.0.1"
+  s.version      = "1.0.2"
   s.summary      = "ActionKit is a easy to use framework that wraps the target-action design paradigm into a closure design."
   s.description  = <<-DESC
                     ActionKit is a experimental, light-weight, easy to use framework that wraps the target-action design paradigm into a less verbose, cleaner format. It shortens target-action method calls by removing the target and replacing the selector with a closure.

--- a/ActionKit/1.1.0/ActionKit.podspec
+++ b/ActionKit/1.1.0/ActionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ActionKit"
-  s.version      = "1.0.2"
+  s.version      = "1.1.0"
   s.summary      = "ActionKit is a easy to use framework that wraps the target-action design paradigm into a closure design."
   s.description  = <<-DESC
                     ActionKit is a experimental, light-weight, easy to use framework that wraps the target-action design paradigm into a less verbose, cleaner format. It shortens target-action method calls by removing the target and replacing the selector with a closure.

--- a/ActionKit/ActionKit.swift
+++ b/ActionKit/ActionKit.swift
@@ -83,8 +83,8 @@ import UIKit
 
 
 typealias ActionKitVoidClosure = () -> Void
-typealias ActionKitControlClosure = (UIControl) -> Void
-typealias ActionKitGestureClosure = (UIGestureRecognizer) -> Void
+public typealias ActionKitControlClosure = (UIControl) -> Void
+public typealias ActionKitGestureClosure = (UIGestureRecognizer) -> Void
 
 enum ActionKitClosure {
     case NoParameters(ActionKitVoidClosure)

--- a/ActionKit/ActionKit.swift
+++ b/ActionKit/ActionKit.swift
@@ -9,6 +9,79 @@
 import Foundation
 import UIKit
 
+//: ## Having an UIControl as optional input parameter for the closure
+//:
+//: We like to have the UIControl as input parameter in the closure, like this:
+//:
+//: ```swift
+//:     button.addControlEvent(.TouchUpInside) { (control: UIControl) in
+//:         print("the control: \(control) was tapped")
+//:     }
+//: ```
+//:
+//: But unfortunately, there is a bug in the swift compiler, that prevents implicit
+//: arguments in the closure. This bug will cause an error when the argument is ignored
+//: implicitly. That means that if you would try to use a closure which has a argument
+//: `(control: UIContol)`, without that argument like this:
+//:
+//: ```swift
+//:     button.addControlEvent(.TouchUpInside) {
+//:         print("this control was tapped")
+//:     }
+//: ```
+//:
+//: Then the compiler will give an error:
+//:
+//: ```Contextual type for closure argument list expects 1 argument, which cannot be implicitlty ignored```
+//:
+//: See Chris Lattner's option on the matter (that this is a compiler bug):
+//: [http://article.gmane.org/gmane.comp.lang.swift.evolution/17196/](http://article.gmane.org/gmane.comp.lang.swift.evolution/17196/)
+//:
+//: ### Workaround by having multiple functions
+//:
+//: We can workaround this bug by having multiple functions, one without the `UIControl` parameter
+//: (the original) and one with the `(control: UIControl) in` parameter. The only downside is that
+//: you will have to call the closure with a specific signature, so either with:
+//:
+//: ```swift
+//:     button.addControlEvent(.TouchUpInside) {
+//:         ...
+//:     }
+//: ```
+//:
+//: or with:
+//:
+//: ```swift
+//:     button.addControlEvent(.TouchUpInside) { (control: UIControl) in
+//:         ...
+//:     }
+//: ```
+//:
+//: but not with:
+//:
+//: ```swift
+//:     button.addControlEvent(.TouchUpInside) { aButton in
+//:         ...
+//:     }
+//: ```
+//:
+//: or with
+//:
+//: ```swift
+//:     button.addControlEvent(.TouchUpInside) { _ in
+//:         ...
+//:     }
+//: ```
+//:
+//: Because `aButton` or `_` is not specific enough and the compiler will complain with:
+//:
+//: ```Ambiguous use of 'addControlEvent'```
+//:
+//: So, until this bug is solved in the Swift compiler, we will have to use **two** functions
+//: for each control event, and be specific with the arguments in the closure call.
+//:
+
+
 typealias ActionKitVoidClosure = () -> Void
 typealias ActionKitControlClosure = (UIControl) -> Void
 typealias ActionKitGestureClosure = (UIGestureRecognizer) -> Void
@@ -30,14 +103,14 @@ class ActionKitSingleton {
         return ActionKit.instance
     }
 }
-//
-//  GESTURE ACTIONS
-//
+
+//:
+//: # GESTURE ACTIONS
+//:
     
 extension ActionKitSingleton {
     
     func addGestureClosure(gesture: UIGestureRecognizer, name: String, closure: ActionKitClosure) {
-//        gestureDict[gesture] = closure
         if var gestureArr = gestureDict[gesture] {
             gestureArr.append(name, closure)
             gestureDict[gesture] = gestureArr
@@ -62,7 +135,6 @@ extension ActionKitSingleton {
     }
     
     func removeGesture(gesture: UIGestureRecognizer, name: String) {
-//        gestureDict.removeValueForKey(gesture)
         if var gestureArray = gestureDict[gesture] {
             var x: Int = 0
             for (index, gestureTuple) in gestureArray.enumerate() {
@@ -99,9 +171,10 @@ extension ActionKitSingleton {
     
 }
 
-//
-// CLOSURE ACTIONS
-//
+//:
+//: # CLOSURE ACTIONS
+//:
+
 extension ActionKitSingleton {
     func removeAction(control: UIControl, controlEvent: UIControlEvents) {
         if var innerDict = controlAndEventsDict[control] {
@@ -121,6 +194,7 @@ extension ActionKitSingleton {
             controlAndEventsDict[control] = newDict
         }
     }
+    
     
     // Start the 19 different runClosure methods, each responding to a different UIControlEvents
     @objc(runClosureTouchDown:)

--- a/ActionKit/Info.plist
+++ b/ActionKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ActionKit/Info.plist
+++ b/ActionKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ActionKit/UIControl+ActionKit.swift
+++ b/ActionKit/UIControl+ActionKit.swift
@@ -89,8 +89,17 @@ public extension UIControl {
         ActionKitSingleton.sharedInstance.removeAction(self, controlEvent: controlEvents)
         
     }
+    
     func addControlEvent(controlEvents: UIControlEvents, closure: () -> ()) {
-        
+        self.addControlEvent(controlEvents, actionKitClosure: .NoParameters(closure))
+    }
+    
+    func addControlEvent(controlEvents: UIControlEvents, closureWithControl: (UIControl) -> ()) {
+        self.addControlEvent(controlEvents, actionKitClosure: .WithControlParameter(closureWithControl))
+    }
+    
+    private func addControlEvent(controlEvents: UIControlEvents, actionKitClosure: ActionKitClosure) {
+
         switch controlEvents {
         case let x where x.contains(.TouchDown):
             self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchDown, forControlEvents: controlEvents)
@@ -134,6 +143,6 @@ public extension UIControl {
             self.addTarget(ActionKitSingleton.sharedInstance, action: .runClosureTouchUpInside, forControlEvents: controlEvents)
         }
         
-        ActionKitSingleton.sharedInstance.addAction(self, controlEvent: controlEvents, closure: closure)
+        ActionKitSingleton.sharedInstance.addAction(self, controlEvent: controlEvents, closure: actionKitClosure)
     }
 }

--- a/ActionKit/UIControl+ActionKit.swift
+++ b/ActionKit/UIControl+ActionKit.swift
@@ -44,13 +44,18 @@ public protocol ActionKitControl {}
 
 public extension ActionKitControl where Self: UIControl {
     
-    typealias SpecificGestureClosure = (Self) -> ()
+    typealias SpecificControlClosure = (Self) -> ()
 
-    func addControlEvent(controlEvents: UIControlEvents, closureWithControl: SpecificGestureClosure) {
-        let akClosure = ActionKitClosure.WithControlParameter(closureWithControl as! ActionKitControlClosure)
+    internal func castedActionKitControlClosure(control: Self, closure: SpecificControlClosure) -> ActionKitClosure {
+        return ActionKitClosure.WithControlParameter( { (ctrl: UIControl) in
+            closure(control)
+        })
+    }
+    
+    func addControlEvent(controlEvents: UIControlEvents, closureWithControl: SpecificControlClosure) {
+        let akClosure = castedActionKitControlClosure(self, closure: closureWithControl)
         self.addControlEvent(controlEvents, actionKitClosure: akClosure)
     }
-
 }
 
 extension UIControl: ActionKitControl {}

--- a/ActionKit/UIControl+ActionKit.swift
+++ b/ActionKit/UIControl+ActionKit.swift
@@ -40,6 +40,21 @@ private extension Selector {
 
 }
 
+public protocol ActionKitControl {}
+
+public extension ActionKitControl where Self: UIControl {
+    
+    typealias SpecificGestureClosure = (Self) -> ()
+
+    func addControlEvent(controlEvents: UIControlEvents, closureWithControl: SpecificGestureClosure) {
+        let akClosure = ActionKitClosure.WithControlParameter(closureWithControl as! ActionKitControlClosure)
+        self.addControlEvent(controlEvents, actionKitClosure: akClosure)
+    }
+
+}
+
+extension UIControl: ActionKitControl {}
+
 public extension UIControl {
     
     func removeControlEvent(controlEvents: UIControlEvents) {
@@ -92,10 +107,6 @@ public extension UIControl {
     
     func addControlEvent(controlEvents: UIControlEvents, closure: () -> ()) {
         self.addControlEvent(controlEvents, actionKitClosure: .NoParameters(closure))
-    }
-    
-    func addControlEvent(controlEvents: UIControlEvents, closureWithControl: (UIControl) -> ()) {
-        self.addControlEvent(controlEvents, actionKitClosure: .WithControlParameter(closureWithControl))
     }
     
     private func addControlEvent(controlEvents: UIControlEvents, actionKitClosure: ActionKitClosure) {

--- a/ActionKit/UIGestureRecognizer+ActionKit.swift
+++ b/ActionKit/UIGestureRecognizer+ActionKit.swift
@@ -15,6 +15,26 @@ private extension Selector {
     
 }
 
+public protocol ActionKitGestureRecognizer {}
+
+public extension ActionKitGestureRecognizer where Self: UIGestureRecognizer {
+
+    typealias SpecificGestureClosure = (Self) -> ()
+    
+    init(name: String = "", closureWithGesture: SpecificGestureClosure) {
+        self.init(target: ActionKitSingleton.sharedInstance, action: .runGesture)
+        let akClosure = ActionKitClosure.WithGestureParameter(closureWithGesture as! ActionKitGestureClosure)
+        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: akClosure)
+    }
+
+    func addClosure(name: String, closureWithGesture: SpecificGestureClosure) {
+        let akClosure = ActionKitClosure.WithGestureParameter(closureWithGesture as! ActionKitGestureClosure)
+        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: akClosure)
+    }
+}
+
+extension UIGestureRecognizer: ActionKitGestureRecognizer {}
+
 public extension UIGestureRecognizer {
     
     convenience init(name: String = "", closure: () -> ()) {
@@ -22,17 +42,8 @@ public extension UIGestureRecognizer {
         ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .NoParameters(closure))
     }
 
-    convenience init(name: String = "", closureWithGesture: (UIGestureRecognizer) -> ()) {
-        self.init(target: ActionKitSingleton.sharedInstance, action: .runGesture)
-        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .WithGestureParameter(closureWithGesture))
-    }
-
     func addClosure(name: String, closure: () -> ()) {
         ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .NoParameters(closure))
-    }
-
-    func addClosure(name: String, closureWithGesture: (UIGestureRecognizer) -> ()) {
-        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .WithGestureParameter(closureWithGesture))
     }
 
     func removeClosure(name: String) {

--- a/ActionKit/UIGestureRecognizer+ActionKit.swift
+++ b/ActionKit/UIGestureRecognizer+ActionKit.swift
@@ -21,14 +21,20 @@ public extension ActionKitGestureRecognizer where Self: UIGestureRecognizer {
 
     typealias SpecificGestureClosure = (Self) -> ()
     
+    internal func castedActionKitGestureClosure(gesture: Self, closure: SpecificGestureClosure) -> ActionKitClosure {
+        return ActionKitClosure.WithGestureParameter( { (gestr: UIGestureRecognizer) in
+            closure(gesture)
+        })
+    }
+    
     init(name: String = "", closureWithGesture: SpecificGestureClosure) {
         self.init(target: ActionKitSingleton.sharedInstance, action: .runGesture)
-        let akClosure = ActionKitClosure.WithGestureParameter(closureWithGesture as! ActionKitGestureClosure)
+        let akClosure = castedActionKitGestureClosure(self, closure: closureWithGesture)
         ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: akClosure)
     }
 
     func addClosure(name: String, closureWithGesture: SpecificGestureClosure) {
-        let akClosure = ActionKitClosure.WithGestureParameter(closureWithGesture as! ActionKitGestureClosure)
+        let akClosure = castedActionKitGestureClosure(self, closure: closureWithGesture)
         ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: akClosure)
     }
 }

--- a/ActionKit/UIGestureRecognizer+ActionKit.swift
+++ b/ActionKit/UIGestureRecognizer+ActionKit.swift
@@ -19,13 +19,22 @@ public extension UIGestureRecognizer {
     
     convenience init(name: String = "", closure: () -> ()) {
         self.init(target: ActionKitSingleton.sharedInstance, action: .runGesture)
-        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: closure)
+        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .NoParameters(closure))
     }
-    
+
+    convenience init(name: String = "", closureWithGesture: (UIGestureRecognizer) -> ()) {
+        self.init(target: ActionKitSingleton.sharedInstance, action: .runGesture)
+        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .WithGestureParameter(closureWithGesture))
+    }
+
     func addClosure(name: String, closure: () -> ()) {
-        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: closure)
+        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .NoParameters(closure))
     }
-    
+
+    func addClosureWithGesture(name: String, closure: (UIGestureRecognizer) -> ()) {
+        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .WithGestureParameter(closure))
+    }
+
     func removeClosure(name: String) {
         if !ActionKitSingleton.sharedInstance.canRemoveGesture(self) {
             print("can remove a gesture closure")

--- a/ActionKit/UIGestureRecognizer+ActionKit.swift
+++ b/ActionKit/UIGestureRecognizer+ActionKit.swift
@@ -31,8 +31,8 @@ public extension UIGestureRecognizer {
         ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .NoParameters(closure))
     }
 
-    func addClosureWithGesture(name: String, closure: (UIGestureRecognizer) -> ()) {
-        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .WithGestureParameter(closure))
+    func addClosure(name: String, closureWithGesture: (UIGestureRecognizer) -> ()) {
+        ActionKitSingleton.sharedInstance.addGestureClosure(self, name: name, closure: .WithGestureParameter(closureWithGesture))
     }
 
     func removeClosure(name: String) {

--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,46 +1,54 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6185.7" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6181.2"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="ActionKit" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="ActionKitDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wXY-dN-UFf">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wXY-dN-UFf">
                                 <rect key="frame" x="20" y="20" width="249" height="72"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="46"/>
                                 <state key="normal" title="Test Button">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UoV-2Z-f8y">
-                                <rect key="frame" x="20" y="100" width="249" height="72"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
-                                <state key="normal" title="Test Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UoV-2Z-f8y">
+                                <rect key="frame" x="20" y="80" width="278" height="72"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="46"/>
+                                <state key="normal" title="Test Button2">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqS-Xg-5Ke">
-                                <rect key="frame" x="20" y="180" width="249" height="72"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
-                                <state key="normal" title="Test Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqS-Xg-5Ke">
+                                <rect key="frame" x="20" y="200" width="338" height="72"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="46"/>
+                                <state key="normal" title="Old Test Button">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lgo-Cg-pa3">
-                                <rect key="frame" x="20" y="260" width="249" height="72"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
-                                <state key="normal" title="Test Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lgo-Cg-pa3">
+                                <rect key="frame" x="20" y="260" width="327" height="72"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="46"/>
+                                <state key="normal" title="Inactive Button">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mjc-0e-Evy">
+                                <rect key="frame" x="20" y="140" width="278" height="72"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="46"/>
+                                <state key="normal" title="Test Button3">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
@@ -48,10 +56,11 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <connections>
+                        <outlet property="inactiveButton" destination="lgo-Cg-pa3" id="kR5-oH-9iX"/>
                         <outlet property="oldTestButton" destination="fqS-Xg-5Ke" id="O2e-bh-nRz"/>
-                        <outlet property="oldTestButton2" destination="lgo-Cg-pa3" id="d6b-BE-lWI"/>
                         <outlet property="testButton" destination="wXY-dN-UFf" id="zBU-Qr-JkI"/>
                         <outlet property="testButton2" destination="UoV-2Z-f8y" id="dCK-qq-89L"/>
+                        <outlet property="testButton3" destination="Mjc-0e-Evy" id="iF9-EM-TID"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -49,10 +49,8 @@ class ViewController: UIViewController {
 
         //: This adds a closure, which receives the UIControl as input parameter, to the third button.
         //: It shows how the UIControl can be mapped to the UIButton, in order to have its title changed.
-        testButton3.addControlEvent(.TouchUpInside) { (control: UIControl) in
-            if let button = control as? UIButton {
-                button.setTitle("Tapped3!", forState: .Normal)
-            }
+        testButton3.addControlEvent(.TouchUpInside) { (button: UIButton) in
+            button.setTitle("Tapped3!", forState: .Normal)
         }
 
         //: The following shows that you can remove a control event that has been set.
@@ -93,7 +91,7 @@ class ViewController: UIViewController {
         //: The following adds a long press gesture recognizer to the background view.
         //: It also shows it is not necessary to keep a reference to the gesture recognizer
         //: when you only need it inside the closure
-        view.addGestureRecognizer(UILongPressGestureRecognizer() { (gesture: UIGestureRecognizer) in
+        view.addGestureRecognizer(UILongPressGestureRecognizer() { (gesture: UILongPressGestureRecognizer) in
             if gesture.state == .Began {
                 let locInView = gesture.locationInView(self.view)
                 self.testButton2.setTitle("\(locInView)", forState: .Normal)

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -44,8 +44,9 @@ class ViewController: UIViewController {
             self.testButton.setTitle("tapped once on the screen!", forState: .Normal)
         }
         
-        let dtgr = UITapGestureRecognizer(name: "setYellow") {
+        let dtgr = UITapGestureRecognizer(name: "setYellow") { (gesture: UIGestureRecognizer) in
             self.view.backgroundColor = UIColor.yellowColor()
+            print(gesture.locationInView(self.view))
         }
         
         
@@ -63,6 +64,12 @@ class ViewController: UIViewController {
         // This shows that you can remove a control event that has been set. Originally, tapping the first button on the screen
         // would set the text to tapped! (line 31), but this removes that.
         testButton.removeControlEvent(.TouchUpInside);
+        
+        oldTestButton2.addControlEvent(.TouchUpInside) { (control: UIControl) in
+            if let button = control as? UIButton {
+                button.setTitle("Tapped3!", forState: .Normal)
+            }
+        }
     }
 
     override func didReceiveMemoryWarning() {

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -11,13 +11,16 @@ import ActionKit
 
 class ViewController: UIViewController {
     
-    // Test buttons used for our implementation of target action
+    // Test buttons used for our implementation of adding control events
     @IBOutlet var testButton: UIButton!
     @IBOutlet var testButton2: UIButton!
+    @IBOutlet var testButton3: UIButton!
     
-    // Test buttons used for a regular usage of target action without ActionKit
+    // Test button used for a regular usage of target action without ActionKit
     @IBOutlet var oldTestButton: UIButton!
-    @IBOutlet var oldTestButton2: UIButton!
+    
+    // Test button used for setting and removing a control event
+    @IBOutlet var inactiveButton: UIButton!
     
     // Part of making old test button changed to tapped. This is what ActionKit tries to avoid doing
     // by removing the need to explicitly declare selector functions when a closure is all that's needed
@@ -27,49 +30,76 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        //: ##Adding UIControl Events
+        //:
+        //: Old style of setting a target and action for the button
+        oldTestButton.addTarget(self, action: #selector(ViewController.tappedSelector(_:)),
+                                forControlEvents: .TouchUpInside)
 
         // This is equivalent to oldTestButton's implementation of setting the action to Tapped
         testButton.addControlEvent(.TouchUpInside) {
             self.testButton.setTitle("Tapped!", forState: .Normal)
         }
-        
-        oldTestButton.addTarget(self, action: #selector(ViewController.tappedSelector(_:)), forControlEvents: .TouchUpInside)
 
-        let tgr = UITapGestureRecognizer(name: "setRed") {
-            self.view.backgroundColor = UIColor.redColor()
-        }
-        // The following three lines will replace the action for the red color gesture recognizer to just change the text of the first test button only. Only one action per gesture recognizer (or a control event for that matter)
-        // More actions per gesture recognizer and for control events are in the works.
-        tgr.addClosure("setButton1") {
-            self.testButton.setTitle("tapped once on the screen!", forState: .Normal)
-        }
-        
-        let dtgr = UITapGestureRecognizer(name: "setYellow") { (gesture: UIGestureRecognizer) in
-            self.view.backgroundColor = UIColor.yellowColor()
-            print(gesture.locationInView(self.view))
-        }
-        
-        
-        dtgr.numberOfTapsRequired = 2
-        // These two gesture recognizers will change the background color of the screen. dtgr will make it yellow on a double tap, tgr makes it red on a single tap. 
-//        tgr.removeClosure("setButton1")
-        view.addGestureRecognizer(dtgr)
-        view.addGestureRecognizer(tgr)
-        
-        // This adds a closure to the second button on the screen to change the text to Tapped2! when being tapped
+        //: This adds a closure to the second button on the screen to change the text to Tapped2! when being tapped
         testButton2.addControlEvent(.TouchUpInside, closure: {
             self.testButton2.setTitle("Tapped2!", forState: .Normal)
-            })
-        
-        // This shows that you can remove a control event that has been set. Originally, tapping the first button on the screen
-        // would set the text to tapped! (line 31), but this removes that.
-        testButton.removeControlEvent(.TouchUpInside);
-        
-        oldTestButton2.addControlEvent(.TouchUpInside) { (control: UIControl) in
+        })
+
+        //: This adds a closure, which receives the UIControl as input parameter, to the third button.
+        //: It shows how the UIControl can be mapped to the UIButton, in order to have its title changed.
+        testButton3.addControlEvent(.TouchUpInside) { (control: UIControl) in
             if let button = control as? UIButton {
                 button.setTitle("Tapped3!", forState: .Normal)
             }
         }
+
+        //: The following shows that you can remove a control event that has been set.
+        //: Initially, tapping the first button on the screen would set the text to "Tapped!" ...
+        inactiveButton.addControlEvent(.TouchUpInside) {
+            self.inactiveButton.setTitle("Tapped!", forState: .Normal)
+        }
+        
+        //: ... but then the following removes that.
+        inactiveButton.removeControlEvent(.TouchUpInside);
+
+        
+        //: #Adding GestureRecognizers
+        //:
+        //: Add a Tap Gesture Recognizer (tgr)
+        let tgr = UITapGestureRecognizer(name: "setRed") {
+            self.view.backgroundColor = UIColor.redColor()
+        }
+        
+        //: The following three lines will add an additional action to the red color gesture recognizer.
+        //:  Multiple actions per gesture recognizer (or control events) are possible.
+        tgr.addClosure("setButton1") {
+            self.testButton.setTitle("Gesture: tapped once!", forState: .Normal)
+        }
+        
+        //: Add a Double Tap Gesture Recognizer (dtgr)
+        let dtgr = UITapGestureRecognizer(name: "setYellow") {
+            self.view.backgroundColor = UIColor.yellowColor()
+        }
+        dtgr.numberOfTapsRequired = 2
+        
+        //: These two gesture recognizers will change the background color of the screen.
+        //: dtgr will make it yellow on a double tap,
+        //: tgr makes it red on a single tap.
+        view.addGestureRecognizer(dtgr)
+        view.addGestureRecognizer(tgr)
+
+        //: The following adds a long press gesture recognizer to the background view.
+        //: It also shows it is not necessary to keep a reference to the gesture recognizer
+        //: when you only need it inside the closure
+        view.addGestureRecognizer(UILongPressGestureRecognizer() { (gesture: UIGestureRecognizer) in
+            if gesture.state == .Began {
+                let locInView = gesture.locationInView(self.view)
+                self.testButton2.setTitle("\(locInView)", forState: .Normal)
+            }
+        })
+        
     }
 
     override func didReceiveMemoryWarning() {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" align="right" vspace="2px">
 
 # ActionKit
+
 ActionKit is a experimental, light-weight, easy to use framework that wraps the target-action design paradigm into a less verbose, cleaner format. It shortens target-action method calls by removing the target and replacing the selector with a closure.
 
 Licensed under the terms of the MIT license
@@ -9,7 +10,6 @@ Licensed under the terms of the MIT license
 ```swift
 button.addTarget(self, action: Selector("buttonWasTapped:"), forControlEvents: .TouchUpInside)
 ```
-
 
 ```swift
 func buttonWasTapped(sender: UIButton!) {
@@ -20,10 +20,10 @@ func buttonWasTapped(sender: UIButton!) {
 ```
 
 ## Target-action example without ActionKit with Swift 2.2
+
 ```swift
 button.addTarget(self, action: #selector(ViewController.buttonWasTapped(_:)), forControlEvents: .TouchUpInside)
 ```
-
 
 ```swift
 func buttonWasTapped(sender: UIButton!) {
@@ -34,6 +34,7 @@ func buttonWasTapped(sender: UIButton!) {
 ```
 
 ## Target-action example with ActionKit
+
 ```swift
 button.addControlEvent(.TouchUpInside) {
   
@@ -43,6 +44,7 @@ button.addControlEvent(.TouchUpInside) {
 ```
 
 ## Target-action example with ActionKit with closure parameter
+
 ```swift
 button.addControlEvent(.TouchUpInside) { (control: UIControl) in
   
@@ -54,14 +56,19 @@ button.addControlEvent(.TouchUpInside) { (control: UIControl) in
 ```
 
 ## Methods
+
 ### UIControl
+
 #### Adding an action closure for a control event
+
 ```swift
 - addControlEvent(controlEvents: UIControlEvents, closure: () -> ())
 
 - addControlEvent(controlEvents: UIControlEvents, closureWithControl: (UIControl) -> ())
 ```
+
 ##### Examples
+
 ```swift
 button.addControlEvent(.TouchUpInside) {
   
@@ -81,22 +88,29 @@ button.addControlEvent(.TouchUpInside) { (control: UIControl) in
 ```
 
 #### Removing an action closure for a control event
+
 ```swift
 - removeControlEvent(controlEvents: UIControlEvents)
 ```
+
 ##### Example
+
 ```swift
 button.removeControlEvent(.TouchUpInside)
 ```
 
 ### UIGestureRecognizer
+
 #### Initializing a gesture recognizer with an action closure
+
 ```swift
 - init(closure: () -> ())
 
 - init(closureWithGesture: (UIGestureRecognizer) -> ())
 ```
+
 ##### Examples
+
 ```swift
 var singleTapGestureRecognizer = UITapGestureRecognizer() {
   
@@ -117,12 +131,15 @@ var singleTapGestureRecognizer = UITapGestureRecognizer() { (gesture: UIGestureR
 ```
 
 #### Adding an action closure to a gesture recognizer
+
 ```swift
 - addClosure(name: String, closure: () -> ())
 
 - addClosure(name: String, closureWithGesture: (UIGestureRecognizer) -> ())
 ```
+
 ##### Example
+
 ```swift
 singleTapGestureRecognizer.addClosure("makeBlue") {
   
@@ -130,42 +147,75 @@ singleTapGestureRecognizer.addClosure("makeBlue") {
 
 }
 ```
+
 #### Removing an action closure for a control event
+
 ```swift
 - removeActionClosure()
 ```
 ##### Example
+
 ```swift
 singleTapGestureRecognizer.removeActionClosure()
 ```
 
 ## How it works
+
 ActionKit extends target-action functionality by providing easy to use methods that take closures instead of a selector. ActionKit uses a singleton which stores the closures and acts as the target. Closures capture and store references to any constants and variables from their context, so the user is free to use variables from the context in which the closure was defined in.
 
+## Migration from previous versions
+
+### Version 1.1.0
+
+Version 1.1.0 adds an *optional* `UIControl` or `UIGestureRecognizer` to the closure. This might lead to possible backwards-incompatibility.
+
+We made sure you can still call the closures without any parameters, like the following:
+
+```swift
+button.addControlEvent(.TouchUpInside) {
+    print("the button was tapped")
+}
+```
+
+However, with previous versions of ActionKit, due to the peculiarity of Swift, it was also possible to call the closure with an unused parameter:
+
+```swift
+button.addControlEvent(.TouchUpInside) { _ in
+    print("the button was tapped")
+}
+```
+
+In this example the `_` refers to the empty input tuple `()`.  
+
+Now, with these extra closure parameters, the above is no longer valid, as it is **ambiguous** which method is being called: `addControlEvent` *without* closure parameters *or with* a `UIControl` as closure parameter. When you have this Xcode will report: **Ambiguous use of 'addControlEvent'**.
+
+If you're using `_ in` in your code and you get this ambiguous error, migrate by *either* removing the `_ in` all together *or* by replacing it with `(control: UIControl) in`. (For gesture recognizers use `(gesture: UIGestureRecognizer) in`.)
+
 ## Supported
+
 - Adding and removing an action to concrete gesture-recognizer objects, eg. UITapGestureRecognizer, UISwipeGestureRecognizer
 - Adding and removing an action for UIControl objects, eg. UIButton, UIView
 
 ## In the pipeline
+
 - Adding and removing multiple actions for a single UIGestureRecognizer
 - Adding and removing multiple actions for a single UIControl
 - Better manage stored closures
 
 ## Installation
 
-
 ### CocoaPods
  ActionKit is available through [CocoaPods](http://cocoapods.org). To install
  it, simply add the following line to your Podfile:
  
-    pod 'ActionKit', '~> 1.0.1'
+    pod 'ActionKit', '~> 1.1.0'
 
 ### Carthage
 
 - 1. Add the following to your *Cartfile*:
 
 ```
-    github "ActionKit/ActionKit" == 1.0.1
+    github "ActionKit/ActionKit" == 1.1.0
 ``` 
    
 - 2. Run `carthage update`

--- a/README.md
+++ b/README.md
@@ -42,13 +42,26 @@ button.addControlEvent(.TouchUpInside) {
 }
 ```
 
+## Target-action example with ActionKit with closure parameter
+```swift
+button.addControlEvent(.TouchUpInside) { (control: UIControl) in
+  
+  if let theButton = control as? UIButton {
+    theButton.setTitle("Button was tapped!", forState: .Normal)
+  }
+
+}
+```
+
 ## Methods
 ### UIControl
 #### Adding an action closure for a control event
 ```swift
 - addControlEvent(controlEvents: UIControlEvents, closure: () -> ())
+
+- addControlEvent(controlEvents: UIControlEvents, closureWithControl: (UIControl) -> ())
 ```
-##### Example
+##### Examples
 ```swift
 button.addControlEvent(.TouchUpInside) {
   
@@ -56,6 +69,17 @@ button.addControlEvent(.TouchUpInside) {
 
 }
 ```
+
+```swift
+button.addControlEvent(.TouchUpInside) { (control: UIControl) in
+  
+  if let theButton = control as? UIButton {
+    theButton.setTitle("Button was tapped!", forState: .Normal)
+  }
+
+}
+```
+
 #### Removing an action closure for a control event
 ```swift
 - removeControlEvent(controlEvents: UIControlEvents)
@@ -64,12 +88,15 @@ button.addControlEvent(.TouchUpInside) {
 ```swift
 button.removeControlEvent(.TouchUpInside)
 ```
+
 ### UIGestureRecognizer
 #### Initializing a gesture recognizer with an action closure
 ```swift
-- init(actionClosure: () -> ())
+- init(closure: () -> ())
+
+- init(closureWithGesture: (UIGestureRecognizer) -> ())
 ```
-##### Example
+##### Examples
 ```swift
 var singleTapGestureRecognizer = UITapGestureRecognizer() {
   
@@ -77,13 +104,27 @@ var singleTapGestureRecognizer = UITapGestureRecognizer() {
 
 }
 ```
+
+```swift
+var singleTapGestureRecognizer = UITapGestureRecognizer() { (gesture: UIGestureRecognizer) in
+  
+  if gesture.state == .Began {
+      let locInView = gesture.locationInView(self.view)
+      ...
+  }
+
+}
+```
+
 #### Adding an action closure to a gesture recognizer
 ```swift
-- addActionClosure(actionClosure: () -> ())
+- addClosure(name: String, closure: () -> ())
+
+- addClosure(name: String, closureWithGesture: (UIGestureRecognizer) -> ())
 ```
 ##### Example
 ```swift
-singleTapGestureRecognizer.addActionClosure() {
+singleTapGestureRecognizer.addClosure("makeBlue") {
   
   self.view.backgroundColor = UIColor.blueColor()
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,9 @@ button.addControlEvent(.TouchUpInside) {
 ## Target-action example with ActionKit with closure parameter
 
 ```swift
-button.addControlEvent(.TouchUpInside) { (control: UIControl) in
+button.addControlEvent(.TouchUpInside) { (button: UIButton) in
   
-  if let theButton = control as? UIButton {
-    theButton.setTitle("Button was tapped!", forState: .Normal)
-  }
+  button.setTitle("Button was tapped!", forState: .Normal)
 
 }
 ```
@@ -78,11 +76,9 @@ button.addControlEvent(.TouchUpInside) {
 ```
 
 ```swift
-button.addControlEvent(.TouchUpInside) { (control: UIControl) in
+button.addControlEvent(.TouchUpInside) { (button: UIButton) in
   
-  if let theButton = control as? UIButton {
-    theButton.setTitle("Button was tapped!", forState: .Normal)
-  }
+    button.setTitle("Button was tapped!", forState: .Normal)
 
 }
 ```
@@ -120,7 +116,7 @@ var singleTapGestureRecognizer = UITapGestureRecognizer() {
 ```
 
 ```swift
-var singleTapGestureRecognizer = UITapGestureRecognizer() { (gesture: UIGestureRecognizer) in
+var singleTapGestureRecognizer = UITapGestureRecognizer() { (gesture: UITapGestureRecognizer) in
   
   if gesture.state == .Began {
       let locInView = gesture.locationInView(self.view)


### PR DESCRIPTION
I like to have the UIControl (or UIGestureRecognizer ) as input parameter in the closure, like this:

```swift
    button.addControlEvent(.TouchUpInside) { (control: UIControl) in
        print("the control: \(control) was tapped")
    }
```

Especially for UIGestureRecognizer's this is useful, because often we need to get details from the gesture recognizer:

```swift
    view.addGestureRecognizer(UITapGestureRecognizer() { (gesture: UIGestureRecognizer) in
        if gesture.state == .Began {
            let locInView = gesture.locationInView(self.view)
        }
    })
```

At the beginning of `ActionKit.swift` I added some explanations about the bugs, concerns and workarounds to implement this.